### PR TITLE
Make the job scheduler easier to use with monad transformer stacks.

### DIFF
--- a/job-scheduler.cabal
+++ b/job-scheduler.cabal
@@ -25,6 +25,8 @@ library
                      , transformers
                      , containers
                      , mtl
+                     , monad-logger
+                     , exceptions
 
 test-suite spec
   default-language:    Haskell2010


### PR DESCRIPTION
This changes the following:
1. Jobs themselves no longer must be instances of Ord.
2. Timer can walk MonadTrans stacks. Any MonadTrans that wraps a type
with a Timer instance is itself a Timer.
3. The Scheduler monad now allows the use of exceptions and logging.